### PR TITLE
Component template and property metadata

### DIFF
--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -51,7 +51,7 @@ export type ComponentTemplateProperties = Record<
 >;
 
 export type ComponentTemplateProperty<T = any> = {
-  type: Union<string, 'enum' | 'boolean' | 'string'>;
+  type: Union<string, 'enum' | 'boolean' | 'string' | 'number'>;
   category?: string;
   description?: string;
   placeholder?: string;

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -11,10 +11,7 @@ export type UserComponentConfig<T> = {
   custom: Record<string, any>;
   info: Record<string, any>;
   isCanvas: boolean;
-
-  // TODO: Deprecate
-  name: string;
-  defaultProps: Partial<T>;
+  template: ComponentTemplate;
 };
 
 export type UserComponent<T = any> = React.ComponentType<T> & {
@@ -33,6 +30,20 @@ export type Node = {
   related: Record<string, React.ElementType>;
   rules: NodeRules;
   _hydrationTimestamp: number;
+};
+
+export type ComponentTemplate = {
+  name: string;
+  description: string;
+  props: Record<string, ComponentTemplateProperty>;
+};
+
+export type ComponentTemplateProperty = {
+  type: 'enum' | 'boolean' | 'string';
+  description?: string;
+  placeholder?: string;
+  values?: readonly string[];
+  default: string | boolean;
 };
 
 export type NormalizeNodeCallback = (node: Node) => void;

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -29,6 +29,7 @@ export type Node = {
   dom: HTMLElement | null;
   related: Record<string, React.ElementType>;
   rules: NodeRules;
+  template: ComponentTemplate;
   _hydrationTimestamp: number;
 };
 

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -53,6 +53,7 @@ export type ComponentTemplateProperties = Record<
 export type ComponentTemplateProperty<T = any> = {
   type: Union<string, 'enum' | 'boolean' | 'string' | 'number'>;
   category?: string;
+  label?: string;
   description?: string;
   placeholder?: string;
   values?: readonly T[];

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -44,12 +44,12 @@ export type ComponentTemplate = {
   props: Record<string, ComponentTemplateProperty>;
 };
 
-export type ComponentTemplateProperty = {
+export type ComponentTemplateProperty<T = unknown> = {
   type: Union<string, 'enum' | 'boolean' | 'string'>;
   description?: string;
   placeholder?: string;
-  values?: readonly any[];
-  default: any;
+  values?: readonly T[];
+  default: T;
 };
 
 export type NormalizeNodeCallback = (node: Node) => void;

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -32,6 +32,12 @@ export type Node = {
   _hydrationTimestamp: number;
 };
 
+// Creates a union type of string literals with strings, but retains intellisense for the literals.
+// Union<string, 'foo' | 'bar'> => string | Omit<string, 'foo' | 'bar'>
+export type Union<S = string, T extends string | number = string> =
+  | T
+  | Omit<S, T>;
+
 export type ComponentTemplate = {
   name: string;
   description: string;
@@ -39,11 +45,11 @@ export type ComponentTemplate = {
 };
 
 export type ComponentTemplateProperty = {
-  type: 'enum' | 'boolean' | 'string';
+  type: Union<string, 'enum' | 'boolean' | 'string'>;
   description?: string;
   placeholder?: string;
-  values?: readonly string[];
-  default: string | boolean;
+  values?: readonly any[];
+  default: any;
 };
 
 export type NormalizeNodeCallback = (node: Node) => void;

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -42,8 +42,13 @@ export type Union<S = string, T extends string | number = string> =
 export type ComponentTemplate = {
   name: string;
   description: string;
-  props: Record<string, ComponentTemplateProperty>;
+  props: ComponentTemplateProperties;
 };
+
+export type ComponentTemplateProperties = Record<
+  string,
+  ComponentTemplateProperty
+>;
 
 export type ComponentTemplateProperty<T = any> = {
   type: Union<string, 'enum' | 'boolean' | 'string'>;

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -52,10 +52,11 @@ export type ComponentTemplateProperties = Record<
 
 export type ComponentTemplateProperty<T = any> = {
   type: Union<string, 'enum' | 'boolean' | 'string'>;
+  category?: string;
   description?: string;
   placeholder?: string;
   values?: readonly T[];
-  default: T;
+  default?: T;
 };
 
 export type NormalizeNodeCallback = (node: Node) => void;

--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -45,7 +45,7 @@ export type ComponentTemplate = {
   props: Record<string, ComponentTemplateProperty>;
 };
 
-export type ComponentTemplateProperty<T = unknown> = {
+export type ComponentTemplateProperty<T = any> = {
   type: Union<string, 'enum' | 'boolean' | 'string'>;
   description?: string;
   placeholder?: string;

--- a/packages/core/src/lib/utils/createNode.ts
+++ b/packages/core/src/lib/utils/createNode.ts
@@ -85,12 +85,10 @@ export function createNode(
 
   if (userComponentConfig) {
     node.data.displayName =
-      userComponentConfig.displayName ||
-      userComponentConfig.name ||
-      node.data.displayName;
+      userComponentConfig.displayName || node.data.displayName;
 
     node.data.props = {
-      ...(userComponentConfig.props || userComponentConfig.defaultProps || {}),
+      ...(userComponentConfig.props || {}),
       ...node.data.props
     };
 

--- a/packages/core/src/lib/utils/createNode.ts
+++ b/packages/core/src/lib/utils/createNode.ts
@@ -131,6 +131,10 @@ export function createNode(
     if (userComponentConfig.info) {
       node.info = userComponentConfig.info;
     }
+
+    if (userComponentConfig.template) {
+      node.template = userComponentConfig.template;
+    }
   }
 
   return node;


### PR DESCRIPTION
Allow providing component property metadata for building property editing and design-time experiences.

Example:

```ts
MyComponent.craft = {
  template: {
    name: 'Box',
    props: {
       display: {
         type: 'enum',
         description: '',
         values: ['none', 'inline', 'inline-block', 'block'],
         default: '',
         placeholder: 'default'
      }
    }
  }
}
```