### PR TITLE
Text type for component templates

### DIFF
--- a/packages/core/src/lib/interfaces/nodes.ts
+++ b/packages/core/src/lib/interfaces/nodes.ts
@@ -51,7 +51,7 @@ export type ComponentTemplateProperties = Record<
 >;
 
 export type ComponentTemplateProperty<T = any> = {
-  type: Union<string, 'enum' | 'boolean' | 'string' | 'number'>;
+  type: Union<string, 'enum' | 'boolean' | 'string' | 'text' | 'number'>;
   category?: string;
   label?: string;
   description?: string;


### PR DESCRIPTION
Support `text` type for the component template properties. This should allow building text inputs for the `string` type while multiline/rich editors for the `text` type.